### PR TITLE
Avoid uncessary maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,8 +3,16 @@ name: Maven Build
 on:
   push:
     branches: [ master ]
+    paths: 
+      - '.mvn/wrapper/**'
+      - 'pom.xml'
+      - 'src/**'    
   pull_request:
     branches: [ master ]
+    paths: 
+      - '.mvn/wrapper/**'
+      - 'pom.xml'
+      - 'src/**'
 
 jobs:
   build:


### PR DESCRIPTION
Maven build will only be executed when there are changes to the following paths:

- .mvn/wrapper
- pom.xml
- src

Closes gh-9.